### PR TITLE
Theme color

### DIFF
--- a/app/drops/yoolk/liquid/instant_website/template_drop.rb
+++ b/app/drops/yoolk/liquid/instant_website/template_drop.rb
@@ -2,12 +2,20 @@ module Yoolk
   module Liquid
     module InstantWebsite
       class TemplateDrop < BaseDrop
-        attributes  :id, :name, :display_name, :description, :developed_by, :developer_url, :demo_website,
+        attributes  :id, :name, :theme_name, :description, :developed_by, :developer_url, :demo_website,
                     :is_responsive, :industries, :pages, :colors,
                     :created_at, :updated_at
 
         belongs_to  :thumbnail,     with: 'Yoolk::Liquid::AttachmentDrop'
         belongs_to  :cover_photo,   with: 'Yoolk::Liquid::InstantWebsite::TemplateCoverPhotoDrop'
+
+        def name
+          object.display_name
+        end
+
+        def theme_name
+          object.name
+        end
       end
     end
   end

--- a/app/drops/yoolk/liquid/instant_website/template_drop.rb
+++ b/app/drops/yoolk/liquid/instant_website/template_drop.rb
@@ -2,7 +2,8 @@ module Yoolk
   module Liquid
     module InstantWebsite
       class TemplateDrop < BaseDrop
-        attributes  :id, :name, :description, :is_responsive, :industries, :pages,
+        attributes  :id, :name, :display_name, :description, :developed_by, :developer_url, :demo_website,
+                    :is_responsive, :industries, :pages, :colors,
                     :created_at, :updated_at
 
         belongs_to  :thumbnail,     with: 'Yoolk::Liquid::AttachmentDrop'

--- a/app/drops/yoolk/liquid/instant_website/website_drop.rb
+++ b/app/drops/yoolk/liquid/instant_website/website_drop.rb
@@ -11,6 +11,10 @@ module Yoolk
 
         has_many    :domains,       with: 'Yoolk::Liquid::InstantWebsite::DomainDrop'
 
+        def color
+          object.color_name
+        end
+
         def office_url
           office_path
         end

--- a/app/drops/yoolk/liquid/instant_website/website_drop.rb
+++ b/app/drops/yoolk/liquid/instant_website/website_drop.rb
@@ -2,7 +2,8 @@ module Yoolk
   module Liquid
     module InstantWebsite
       class WebsiteDrop < BaseDrop
-        attributes  :id, :google_analytics_key, :is_live, :is_active, :free_plan, :template_name,
+        attributes  :id, :google_analytics_key, :is_live, :is_active, :free_plan,
+                    :template_name, :color,
                     :primary_domain, :created_at, :updated_at
 
         belongs_to  :favicon,       with: 'Yoolk::Liquid::AttachmentDrop'

--- a/app/drops/yoolk/liquid/request_drop.rb
+++ b/app/drops/yoolk/liquid/request_drop.rb
@@ -94,8 +94,13 @@ module Yoolk
         request.params[:theme]
       end
 
+      # theme_style_url is deprecated due to the rename of style to color
       def theme_style_url
-        controller.theme_style_url
+        controller.theme_color_url
+      end
+
+      def theme_color_url
+        controller.theme_color_url
       end
 
       def style_name

--- a/app/drops/yoolk/liquid/request_drop.rb
+++ b/app/drops/yoolk/liquid/request_drop.rb
@@ -105,10 +105,10 @@ module Yoolk
 
       # style_name is deprecated due to the rename to color
       def style_name
-        color
+        theme_color
       end
 
-      def color
+      def theme_color
         request.params[:color]
       end
 
@@ -122,8 +122,8 @@ module Yoolk
        "Views.#{controller.class.name.gsub('::', '.').gsub(/Controller$/, '')}.#{action.camelize}View"
       end
 
-      def page_name
-        controller.controller_path.split("/")[0].gsub("_", "-")
+      def css_class_name
+        controller.controller_path.split('/')[0].gsub('_', '-')
       end
 
       private

--- a/app/drops/yoolk/liquid/request_drop.rb
+++ b/app/drops/yoolk/liquid/request_drop.rb
@@ -94,17 +94,22 @@ module Yoolk
         request.params[:theme]
       end
 
-      # theme_style_url is deprecated due to the rename of style to color
+      # theme_style_url is deprecated due to the rename to color
       def theme_style_url
-        controller.theme_color_url
+        theme_color_url
       end
 
       def theme_color_url
         controller.theme_color_url
       end
 
+      # style_name is deprecated due to the rename to color
       def style_name
-        request.params[:style]
+        color
+      end
+
+      def color
+        request.params[:color]
       end
 
       def js_class_name

--- a/app/models/yoolk/sandbox/instant_website/template.rb
+++ b/app/models/yoolk/sandbox/instant_website/template.rb
@@ -5,11 +5,15 @@ module Yoolk
 
         attribute :id,               String
         attribute :name,             String
+        attribute :display_name,     String
+        attribute :developed_by,     String
+        attribute :demo_website,     String
+        attribute :developer_url,    String
         attribute :description,      String
         attribute :is_responsive,    Boolean
         attribute :industries,       Array
         attribute :pages,            Array
-        attribute :styles,           Array
+        attribute :colors,           Array
         attribute :created_at,       DateTime
         attribute :updated_at,       DateTime
 

--- a/app/models/yoolk/sandbox/instant_website/template_color.rb
+++ b/app/models/yoolk/sandbox/instant_website/template_color.rb
@@ -1,0 +1,14 @@
+module Yoolk
+  module Sandbox
+    module InstantWebsite
+      class TemplateColor < Yoolk::Sandbox::Base
+
+        attribute :id,                    String
+        attribute :name,                  String
+        attribute :code,                  String
+        attribute :created_at,            DateTime
+        attribute :updated_at,            DateTime
+      end
+    end
+  end
+end

--- a/app/models/yoolk/sandbox/instant_website/website.rb
+++ b/app/models/yoolk/sandbox/instant_website/website.rb
@@ -8,7 +8,7 @@ module Yoolk
         attribute :is_live,               Boolean
         attribute :is_active,             Boolean
         attribute :free_plan,             Boolean
-        attribute :style_name,            String
+        attribute :color,                 String
         attribute :created_at,            DateTime
         attribute :updated_at,            DateTime
 

--- a/app/models/yoolk/sandbox/instant_website/website.rb
+++ b/app/models/yoolk/sandbox/instant_website/website.rb
@@ -8,7 +8,7 @@ module Yoolk
         attribute :is_live,               Boolean
         attribute :is_active,             Boolean
         attribute :free_plan,             Boolean
-        attribute :color,                 String
+        attribute :color_name,            String
         attribute :created_at,            DateTime
         attribute :updated_at,            DateTime
 

--- a/spec/drops/yoolk/liquid/instant_website/template_drop_spec.rb
+++ b/spec/drops/yoolk/liquid/instant_website/template_drop_spec.rb
@@ -5,10 +5,15 @@ module Yoolk
     describe InstantWebsite::TemplateDrop do
       it { should have_attribute(:id) }
       it { should have_attribute(:name) }
+      it { should have_attribute(:display_name) }
       it { should have_attribute(:description) }
+      it { should have_attribute(:developer_url) }
+      it { should have_attribute(:developed_by) }
+      it { should have_attribute(:demo_website) }
       it { should have_attribute(:is_responsive) }
       it { should have_attribute(:industries) }
       it { should have_attribute(:pages) }
+      it { should have_attribute(:colors) }
       it { should have_attribute(:created_at) }
       it { should have_attribute(:updated_at) }
 

--- a/spec/drops/yoolk/liquid/instant_website/template_drop_spec.rb
+++ b/spec/drops/yoolk/liquid/instant_website/template_drop_spec.rb
@@ -5,7 +5,7 @@ module Yoolk
     describe InstantWebsite::TemplateDrop do
       it { should have_attribute(:id) }
       it { should have_attribute(:name) }
-      it { should have_attribute(:display_name) }
+      it { should have_attribute(:theme_name) }
       it { should have_attribute(:description) }
       it { should have_attribute(:developer_url) }
       it { should have_attribute(:developed_by) }

--- a/spec/drops/yoolk/liquid/instant_website/website_drop_spec.rb
+++ b/spec/drops/yoolk/liquid/instant_website/website_drop_spec.rb
@@ -4,6 +4,8 @@ module Yoolk
   module Liquid
     describe InstantWebsite::WebsiteDrop do
       it { should have_attribute(:id) }
+      it { should have_attribute(:template_name) }
+      it { should have_attribute(:color) }
       it { should have_attribute(:google_analytics_key) }
       it { should have_attribute(:is_live) }
       it { should have_attribute(:is_active) }

--- a/spec/drops/yoolk/liquid/request_drop_spec.rb
+++ b/spec/drops/yoolk/liquid/request_drop_spec.rb
@@ -79,10 +79,10 @@ module Yoolk
         expect(subject.theme_name).to eq('sample')
       end
 
-      it '#color' do
+      it '#theme_color' do
         allow(subject.send(:request)).to receive(:params).and_return(color: 'gray')
 
-        expect(subject.color).to eq('gray')
+        expect(subject.theme_color).to eq('gray')
       end
 
       context '#js_class_name' do

--- a/spec/drops/yoolk/liquid/request_drop_spec.rb
+++ b/spec/drops/yoolk/liquid/request_drop_spec.rb
@@ -79,10 +79,10 @@ module Yoolk
         expect(subject.theme_name).to eq('sample')
       end
 
-      it '#style_name' do
-        allow(subject.send(:request)).to receive(:params).and_return(style: 'gray')
+      it '#color' do
+        allow(subject.send(:request)).to receive(:params).and_return(color: 'gray')
 
-        expect(subject.style_name).to eq('gray')
+        expect(subject.color).to eq('gray')
       end
 
       context '#js_class_name' do

--- a/spec/models/yoolk/sandbox/instant_website/template_color_spec.rb
+++ b/spec/models/yoolk/sandbox/instant_website/template_color_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+module Yoolk
+  module Sandbox
+    describe InstantWebsite::TemplateColor do
+      it 'has :id attribute' do
+        expect(described_class).to have_attribute(:id).of_type(String)
+      end
+
+      it 'has :name attribute' do
+        expect(described_class).to have_attribute(:name).of_type(String)
+      end
+
+      it 'has :code attribute' do
+        expect(described_class).to have_attribute(:code).of_type(String)
+      end
+
+      it 'has :created_at attribute' do
+        expect(described_class).to have_attribute(:created_at).of_type(DateTime)
+      end
+
+      it 'has :updated_at attribute' do
+        expect(described_class).to have_attribute(:updated_at).of_type(DateTime)
+      end
+    end
+  end
+end

--- a/spec/models/yoolk/sandbox/instant_website/template_spec.rb
+++ b/spec/models/yoolk/sandbox/instant_website/template_spec.rb
@@ -12,6 +12,22 @@ module Yoolk
         expect(described_class).to have_attribute(:name).of_type(String)
       end
 
+      it 'has :display_name attribute' do
+        expect(described_class).to have_attribute(:display_name).of_type(String)
+      end
+
+      it 'has :developed_by attribute' do
+        expect(described_class).to have_attribute(:developed_by).of_type(String)
+      end
+
+      it 'has :developer_url attribute' do
+        expect(described_class).to have_attribute(:developer_url).of_type(String)
+      end
+
+      it 'has :demo_website attribute' do
+        expect(described_class).to have_attribute(:demo_website).of_type(String)
+      end
+
       it 'has :description attribute' do
         expect(described_class).to have_attribute(:description).of_type(String)
       end
@@ -28,8 +44,8 @@ module Yoolk
         expect(described_class).to have_attribute(:pages).of_type(Array)
       end
 
-      it 'has :styles attribute' do
-        expect(described_class).to have_attribute(:styles).of_type(Array)
+      it 'has :colors attribute' do
+        expect(described_class).to have_attribute(:colors).of_type(Array)
       end
 
       it 'has :created_at attribute' do

--- a/spec/models/yoolk/sandbox/instant_website/website_spec.rb
+++ b/spec/models/yoolk/sandbox/instant_website/website_spec.rb
@@ -23,8 +23,8 @@ module Yoolk
         expect(described_class).to have_attribute(:free_plan)
       end
 
-      it 'has :style_name attribute' do
-        expect(described_class).to have_attribute(:style_name)
+      it 'has :color attribute' do
+        expect(described_class).to have_attribute(:color)
       end
 
       it 'has :created_at attribute' do

--- a/spec/models/yoolk/sandbox/instant_website/website_spec.rb
+++ b/spec/models/yoolk/sandbox/instant_website/website_spec.rb
@@ -23,8 +23,8 @@ module Yoolk
         expect(described_class).to have_attribute(:free_plan)
       end
 
-      it 'has :color attribute' do
-        expect(described_class).to have_attribute(:color)
+      it 'has :color_name attribute' do
+        expect(described_class).to have_attribute(:color_name)
       end
 
       it 'has :created_at attribute' do


### PR DESCRIPTION
Style has been renamed to 'color'. These below two methods are deprecated:
1. request.style_name => request.color
2. request.theme_style_url => request.theme_color_url