### PR TITLE
fix copyright to display good in iwtemplates as liquid templates

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,6 @@ en:
     open:                       "Open"
     closed:                     "Closed"
     today:                      "Today"
-    copyright:                  "Copyright &copy; %{year}. All Rights Reserved"
+    copyright:                  "Copyright © %{year}. All Rights Reserved"
     activities:                 "Activities"
     price:                      "Price"


### PR DESCRIPTION
- [x] fix copyright not display © in iwtemplates as liquid templates.